### PR TITLE
DoodleCollectionViewController Cell에 이미지 fetch 전까지 구현

### DIFF
--- a/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
+++ b/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
@@ -108,9 +108,9 @@
 			isa = PBXGroup;
 			children = (
 				6A1FB8A9241F54B800483229 /* PhotoCell.swift */,
-				6A067F772421FB15005A3701 /* DoodleImageCell.swift */,
 				6A559D922420A20D00028232 /* PhotoCollectionViewDelegateFlowLayout.swift */,
 				6A067F732421F5BF005A3701 /* DoodleCollectionViewDelegateFlowLayout.swift */,
+				6A067F772421FB15005A3701 /* DoodleImageCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";

--- a/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
+++ b/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
@@ -13,10 +13,13 @@
 		380348F3241F44CB002C91FC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 380348F1241F44CB002C91FC /* Main.storyboard */; };
 		380348F5241F44CD002C91FC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 380348F4241F44CD002C91FC /* Assets.xcassets */; };
 		380348F8241F44CD002C91FC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 380348F6241F44CD002C91FC /* LaunchScreen.storyboard */; };
+		6A067F742421F5BF005A3701 /* DoodleCollectionViewDelegateFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A067F732421F5BF005A3701 /* DoodleCollectionViewDelegateFlowLayout.swift */; };
+		6A067F762421F762005A3701 /* DoodleCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A067F752421F762005A3701 /* DoodleCollectionViewDataSource.swift */; };
 		6A1FB8A8241F48D000483229 /* PhotoCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1FB8A7241F48D000483229 /* PhotoCollectionViewDataSource.swift */; };
 		6A1FB8AA241F54B800483229 /* PhotoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1FB8A9241F54B800483229 /* PhotoCell.swift */; };
 		6A559D932420A20D00028232 /* PhotoCollectionViewDelegateFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A559D922420A20D00028232 /* PhotoCollectionViewDelegateFlowLayout.swift */; };
 		6A78D8072420D3B400A27BDE /* NSNotification.Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A78D8062420D3B400A27BDE /* NSNotification.Name.swift */; };
+		6A78D8092421B91B00A27BDE /* DoodleCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A78D8082421B91B00A27BDE /* DoodleCollectionViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,10 +31,13 @@
 		380348F4241F44CD002C91FC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		380348F7241F44CD002C91FC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		380348F9241F44CD002C91FC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6A067F732421F5BF005A3701 /* DoodleCollectionViewDelegateFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoodleCollectionViewDelegateFlowLayout.swift; sourceTree = "<group>"; };
+		6A067F752421F762005A3701 /* DoodleCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoodleCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		6A1FB8A7241F48D000483229 /* PhotoCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		6A1FB8A9241F54B800483229 /* PhotoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCell.swift; sourceTree = "<group>"; };
 		6A559D922420A20D00028232 /* PhotoCollectionViewDelegateFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCollectionViewDelegateFlowLayout.swift; sourceTree = "<group>"; };
 		6A78D8062420D3B400A27BDE /* NSNotification.Name.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSNotification.Name.swift; sourceTree = "<group>"; };
+		6A78D8082421B91B00A27BDE /* DoodleCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoodleCollectionViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +88,7 @@
 			isa = PBXGroup;
 			children = (
 				380348EF241F44CB002C91FC /* ViewController.swift */,
+				6A78D8082421B91B00A27BDE /* DoodleCollectionViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -90,6 +97,7 @@
 			isa = PBXGroup;
 			children = (
 				6A1FB8A7241F48D000483229 /* PhotoCollectionViewDataSource.swift */,
+				6A067F752421F762005A3701 /* DoodleCollectionViewDataSource.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -99,6 +107,7 @@
 			children = (
 				6A1FB8A9241F54B800483229 /* PhotoCell.swift */,
 				6A559D922420A20D00028232 /* PhotoCollectionViewDelegateFlowLayout.swift */,
+				6A067F732421F5BF005A3701 /* DoodleCollectionViewDelegateFlowLayout.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -182,10 +191,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6A067F742421F5BF005A3701 /* DoodleCollectionViewDelegateFlowLayout.swift in Sources */,
 				380348F0241F44CB002C91FC /* ViewController.swift in Sources */,
+				6A78D8092421B91B00A27BDE /* DoodleCollectionViewController.swift in Sources */,
 				6A1FB8AA241F54B800483229 /* PhotoCell.swift in Sources */,
 				6A559D932420A20D00028232 /* PhotoCollectionViewDelegateFlowLayout.swift in Sources */,
 				380348EC241F44CB002C91FC /* AppDelegate.swift in Sources */,
+				6A067F762421F762005A3701 /* DoodleCollectionViewDataSource.swift in Sources */,
 				6A1FB8A8241F48D000483229 /* PhotoCollectionViewDataSource.swift in Sources */,
 				380348EE241F44CB002C91FC /* SceneDelegate.swift in Sources */,
 				6A78D8072420D3B400A27BDE /* NSNotification.Name.swift in Sources */,

--- a/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
+++ b/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		380348F8241F44CD002C91FC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 380348F6241F44CD002C91FC /* LaunchScreen.storyboard */; };
 		6A067F742421F5BF005A3701 /* DoodleCollectionViewDelegateFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A067F732421F5BF005A3701 /* DoodleCollectionViewDelegateFlowLayout.swift */; };
 		6A067F762421F762005A3701 /* DoodleCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A067F752421F762005A3701 /* DoodleCollectionViewDataSource.swift */; };
+		6A067F782421FB15005A3701 /* DoodleImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A067F772421FB15005A3701 /* DoodleImageCell.swift */; };
 		6A1FB8A8241F48D000483229 /* PhotoCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1FB8A7241F48D000483229 /* PhotoCollectionViewDataSource.swift */; };
 		6A1FB8AA241F54B800483229 /* PhotoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1FB8A9241F54B800483229 /* PhotoCell.swift */; };
 		6A559D932420A20D00028232 /* PhotoCollectionViewDelegateFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A559D922420A20D00028232 /* PhotoCollectionViewDelegateFlowLayout.swift */; };
@@ -33,6 +34,7 @@
 		380348F9241F44CD002C91FC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6A067F732421F5BF005A3701 /* DoodleCollectionViewDelegateFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoodleCollectionViewDelegateFlowLayout.swift; sourceTree = "<group>"; };
 		6A067F752421F762005A3701 /* DoodleCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoodleCollectionViewDataSource.swift; sourceTree = "<group>"; };
+		6A067F772421FB15005A3701 /* DoodleImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoodleImageCell.swift; sourceTree = "<group>"; };
 		6A1FB8A7241F48D000483229 /* PhotoCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		6A1FB8A9241F54B800483229 /* PhotoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCell.swift; sourceTree = "<group>"; };
 		6A559D922420A20D00028232 /* PhotoCollectionViewDelegateFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCollectionViewDelegateFlowLayout.swift; sourceTree = "<group>"; };
@@ -106,6 +108,7 @@
 			isa = PBXGroup;
 			children = (
 				6A1FB8A9241F54B800483229 /* PhotoCell.swift */,
+				6A067F772421FB15005A3701 /* DoodleImageCell.swift */,
 				6A559D922420A20D00028232 /* PhotoCollectionViewDelegateFlowLayout.swift */,
 				6A067F732421F5BF005A3701 /* DoodleCollectionViewDelegateFlowLayout.swift */,
 			);
@@ -196,6 +199,7 @@
 				6A78D8092421B91B00A27BDE /* DoodleCollectionViewController.swift in Sources */,
 				6A1FB8AA241F54B800483229 /* PhotoCell.swift in Sources */,
 				6A559D932420A20D00028232 /* PhotoCollectionViewDelegateFlowLayout.swift in Sources */,
+				6A067F782421FB15005A3701 /* DoodleImageCell.swift in Sources */,
 				380348EC241F44CB002C91FC /* AppDelegate.swift in Sources */,
 				6A067F762421F762005A3701 /* DoodleCollectionViewDataSource.swift in Sources */,
 				6A1FB8A8241F48D000483229 /* PhotoCollectionViewDataSource.swift in Sources */,

--- a/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
+++ b/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
@@ -205,9 +205,11 @@
 			files = (
 				6A067F742421F5BF005A3701 /* DoodleCollectionViewDelegateFlowLayout.swift in Sources */,
 				380348F0241F44CB002C91FC /* ViewController.swift in Sources */,
+				6A78D8092421B91B00A27BDE /* DoodleCollectionViewController.swift in Sources */,
 				38CCC2A22421B80700E12D82 /* DoodleImage.swift in Sources */,
 				6A1FB8AA241F54B800483229 /* PhotoCell.swift in Sources */,
 				6A559D932420A20D00028232 /* PhotoCollectionViewDelegateFlowLayout.swift in Sources */,
+				6A067F782421FB15005A3701 /* DoodleImageCell.swift in Sources */,
 				38CCC2A42421B81F00E12D82 /* DateFormatter.swift in Sources */,
 				380348EC241F44CB002C91FC /* AppDelegate.swift in Sources */,
 				6A067F762421F762005A3701 /* DoodleCollectionViewDataSource.swift in Sources */,

--- a/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
+++ b/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
@@ -62,9 +62,14 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <navigationItem key="navigationItem" id="fHI-pz-ZQR">
+                        <barButtonItem key="leftBarButtonItem" style="plain" systemItem="add" id="brn-dS-ct8">
+                            <connections>
+                                <action selector="getAndAddImageButtonTapped:" destination="BYZ-38-t0r" id="V1p-Dl-N3W"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" title="Add" id="s16-5p-UmU">
                             <connections>
-                                <action selector="addImageButtonTapped:" destination="BYZ-38-t0r" id="AqC-Fb-mqf"/>
+                                <action selector="addImageButtonTapped:" destination="BYZ-38-t0r" id="3l4-kz-jyo"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -74,7 +79,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1047.8260869565217" y="137.94642857142856"/>
+            <point key="canvasLocation" x="1028" y="138"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="zTd-iv-eOq">

--- a/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
+++ b/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="sP0-q5-k0N">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -13,11 +12,11 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="PhotosApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="TVc-in-tuS">
-                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
+                                <rect key="frame" x="0.0" y="44" width="600" height="556"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="2zP-17-eXm">
                                     <size key="itemSize" width="80" height="80"/>
@@ -64,7 +63,7 @@
                     <navigationItem key="navigationItem" id="fHI-pz-ZQR">
                         <barButtonItem key="leftBarButtonItem" style="plain" systemItem="add" id="brn-dS-ct8">
                             <connections>
-                                <action selector="getAndAddImageButtonTapped:" destination="BYZ-38-t0r" id="V1p-Dl-N3W"/>
+                                <action selector="presentDoodleCollectionViewController:" destination="BYZ-38-t0r" id="V1p-Dl-N3W"/>
                             </connections>
                         </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" title="Add" id="s16-5p-UmU">

--- a/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
+++ b/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 class DoodleCollectionViewController: UICollectionViewController {
+    
     private let navigationBarTitle = "Doodles"
     private let delegateFlowLayout = DoodleCollectionViewDelegateFlowLayout()
     private let dataSource = DoodleCollectionViewDataSource()

--- a/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
+++ b/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
@@ -22,7 +22,7 @@ class DoodleCollectionViewController: UICollectionViewController {
     private func setupCollectionView() {
         self.collectionView.dataSource = dataSource
         self.collectionView.delegate = delegateFlowLayout
-        self.collectionView.register(DoodleImageCell.self, forCellWithReuseIdentifier: DoodleImageCell.cellIdentifier)
+        self.collectionView.register(DoodleImageCell.self, forCellWithReuseIdentifier: DoodleImageCell.identifier)
         self.collectionView.backgroundColor = .darkGray
     }
 

--- a/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
+++ b/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 class DoodleCollectionViewController: UICollectionViewController {
-    private let reuseIdentifier = "Cell"
     private let navigationBarTitle = "Doodles"
     private let delegateFlowLayout = DoodleCollectionViewDelegateFlowLayout()
     private let dataSource = DoodleCollectionViewDataSource()
@@ -23,7 +22,7 @@ class DoodleCollectionViewController: UICollectionViewController {
     private func setupCollectionView() {
         self.collectionView.dataSource = dataSource
         self.collectionView.delegate = delegateFlowLayout
-        self.collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: reuseIdentifier)
+        self.collectionView.register(DoodleImageCell.self, forCellWithReuseIdentifier: DoodleImageCell.cellIdentifier)
         self.collectionView.backgroundColor = .darkGray
     }
 

--- a/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
+++ b/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
@@ -1,0 +1,38 @@
+//
+//  DoodleCollectionViewController.swift
+//  PhotosApp
+//
+//  Created by Keunna Lee on 2020/03/18.
+//  Copyright © 2020 corykim0829. All rights reserved.
+//
+
+import UIKit
+
+class DoodleCollectionViewController: UICollectionViewController {
+    private let reuseIdentifier = "Cell"
+    private let navigationBarTitle = "Doodles"
+    private let delegateFlowLayout = DoodleCollectionViewDelegateFlowLayout()
+    private let dataSource = DoodleCollectionViewDataSource()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupCollectionView()
+        setupNavigationBar()
+    }
+    
+    private func setupCollectionView() {
+        self.collectionView.dataSource = dataSource
+        self.collectionView.delegate = delegateFlowLayout
+        self.collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: reuseIdentifier)
+        self.collectionView.backgroundColor = .darkGray
+    }
+
+    private func setupNavigationBar() {
+        navigationItem.title = navigationBarTitle
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Close", style: .plain, target: self, action: #selector(closeButtonTapped))
+    }
+    
+    @objc func closeButtonTapped() {
+        self.dismiss(animated: true, completion: nil)
+    }
+}

--- a/PhotosApp/PhotosApp/Controllers/ViewController.swift
+++ b/PhotosApp/PhotosApp/Controllers/ViewController.swift
@@ -19,7 +19,7 @@ class ViewController: UIViewController {
         dataSource.addImage()
     }
     
-    @IBAction func getAndAddImageButtonTapped(_ sender: UIBarButtonItem) {
+    @IBAction func presentDoodleCollectionViewController(_ sender: UIBarButtonItem) {
         let layout = UICollectionViewFlowLayout()
         let doodleCollectionView = DoodleCollectionViewController(collectionViewLayout: layout)
         let navigationController = UINavigationController(rootViewController: doodleCollectionView)

--- a/PhotosApp/PhotosApp/Controllers/ViewController.swift
+++ b/PhotosApp/PhotosApp/Controllers/ViewController.swift
@@ -20,7 +20,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func getAndAddImageButtonTapped(_ sender: UIBarButtonItem) {
-        let layout = UICollectionViewLayout()
+        let layout = UICollectionViewFlowLayout()
         let doodleCollectionView = DoodleCollectionViewController(collectionViewLayout: layout)
         let navigationController = UINavigationController(rootViewController: doodleCollectionView)
         navigationController.modalPresentationStyle = .overFullScreen
@@ -29,7 +29,6 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         setupCollectionView()
         setupNavigationBarTitle()
         setupNotification()

--- a/PhotosApp/PhotosApp/Controllers/ViewController.swift
+++ b/PhotosApp/PhotosApp/Controllers/ViewController.swift
@@ -19,6 +19,14 @@ class ViewController: UIViewController {
         dataSource.addImage()
     }
     
+    @IBAction func getAndAddImageButtonTapped(_ sender: UIBarButtonItem) {
+        let layout = UICollectionViewLayout()
+        let doodleCollectionView = DoodleCollectionViewController(collectionViewLayout: layout)
+        let navigationController = UINavigationController(rootViewController: doodleCollectionView)
+        navigationController.modalPresentationStyle = .overFullScreen
+        self.present(navigationController, animated: true)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/PhotosApp/PhotosApp/Models/DoodleCollectionViewDataSource.swift
+++ b/PhotosApp/PhotosApp/Models/DoodleCollectionViewDataSource.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 class DoodleCollectionViewDataSource: NSObject, UICollectionViewDataSource {
+    
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return 10
     }

--- a/PhotosApp/PhotosApp/Models/DoodleCollectionViewDataSource.swift
+++ b/PhotosApp/PhotosApp/Models/DoodleCollectionViewDataSource.swift
@@ -7,15 +7,14 @@
 //
 
 import UIKit
-import Photos
 
 class DoodleCollectionViewDataSource: NSObject, UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 0
+        return 10
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = UICollectionViewCell()
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DoodleImageCell.cellIdentifier, for: indexPath) as! DoodleImageCell
         return cell
     }
 }

--- a/PhotosApp/PhotosApp/Models/DoodleCollectionViewDataSource.swift
+++ b/PhotosApp/PhotosApp/Models/DoodleCollectionViewDataSource.swift
@@ -1,0 +1,21 @@
+//
+//  DoodleViewControllerDataSource.swift
+//  PhotosApp
+//
+//  Created by Keunna Lee on 2020/03/18.
+//  Copyright © 2020 corykim0829. All rights reserved.
+//
+
+import UIKit
+import Photos
+
+class DoodleCollectionViewDataSource: NSObject, UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 0
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = UICollectionViewCell()
+        return cell
+    }
+}

--- a/PhotosApp/PhotosApp/Models/DoodleCollectionViewDataSource.swift
+++ b/PhotosApp/PhotosApp/Models/DoodleCollectionViewDataSource.swift
@@ -14,7 +14,7 @@ class DoodleCollectionViewDataSource: NSObject, UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DoodleImageCell.cellIdentifier, for: indexPath) as! DoodleImageCell
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DoodleImageCell.identifier, for: indexPath) as! DoodleImageCell
         return cell
     }
 }

--- a/PhotosApp/PhotosApp/Models/PhotoCollectionViewDataSource.swift
+++ b/PhotosApp/PhotosApp/Models/PhotoCollectionViewDataSource.swift
@@ -43,7 +43,7 @@ class PhotoCollectionViewDataSource: NSObject, UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PhotoCell.cellIdentifier, for: indexPath) as! PhotoCell
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PhotoCell.identifier, for: indexPath) as! PhotoCell
         let asset = fetchResult.object(at: indexPath.item)
         imageManager.requestImage(for: asset, targetSize: targetSize, contentMode: .aspectFill, options: nil) { (image, _) in
             cell.thumbnailImage = image

--- a/PhotosApp/PhotosApp/Views/DoodleCollectionViewDelegateFlowLayout.swift
+++ b/PhotosApp/PhotosApp/Views/DoodleCollectionViewDelegateFlowLayout.swift
@@ -1,0 +1,18 @@
+//
+//  DoodleCollectionViewDelegateFlowLayout.swift
+//  PhotosApp
+//
+//  Created by Keunna Lee on 2020/03/18.
+//  Copyright © 2020 corykim0829. All rights reserved.
+//
+
+import UIKit
+
+class DoodleCollectionViewDelegateFlowLayout: NSObject, UICollectionViewDelegateFlowLayout {
+    
+    let cellSize = CGSize(width: 110, height: 50)
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return cellSize
+    }
+}

--- a/PhotosApp/PhotosApp/Views/DoodleImageCell.swift
+++ b/PhotosApp/PhotosApp/Views/DoodleImageCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class DoodleImageCell: UICollectionViewCell {
     
-    static let cellIdentifier = "doodleImageCell"
+    static let identifier = "doodleImageCell"
     let doodleImageView : UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFill

--- a/PhotosApp/PhotosApp/Views/DoodleImageCell.swift
+++ b/PhotosApp/PhotosApp/Views/DoodleImageCell.swift
@@ -1,0 +1,45 @@
+//
+//  DoodleImageCell.swift
+//  PhotosApp
+//
+//  Created by Keunna Lee on 2020/03/18.
+//  Copyright © 2020 corykim0829. All rights reserved.
+//
+
+import UIKit
+
+class DoodleImageCell: UICollectionViewCell {
+    
+    static let cellIdentifier = "doodleImageCell"
+    let doodleImageView : UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        return imageView
+    }()
+    var doodleImage : UIImage! {
+        didSet {
+            doodleImageView.image = doodleImage
+        }
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+    
+    private func setupUI() {
+        doodleImage = #imageLiteral(resourceName: "codesquad")
+        addSubview(doodleImageView)
+        doodleImageView.translatesAutoresizingMaskIntoConstraints = false
+        doodleImageView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        doodleImageView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        doodleImageView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+        doodleImageView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+    }
+}
+

--- a/PhotosApp/PhotosApp/Views/PhotoCell.swift
+++ b/PhotosApp/PhotosApp/Views/PhotoCell.swift
@@ -11,7 +11,7 @@ import UIKit
 class PhotoCell: UICollectionViewCell {
     
     @IBOutlet weak var thumbnailImageView: UIImageView!
-    static let cellIdentifier = "photoCell"
+    static let identifier = "photoCell"
     var thumbnailImage : UIImage! {
         didSet {
             thumbnailImageView.image = thumbnailImage


### PR DESCRIPTION
### 고민한 점 & 어려웠던 점
1. \+ 버튼을 눌렀을 때 DoodleCollectionViewController 가 떠오르지 않는 문제가 있었는데, 원인을 찾는데에 시간이 많이 걸렸습니다.. :(
2. DoodleCollectionViewController 클래스를 만들 때 자동완성되는 부분은 강하게 신뢰해서 바꿀 생각을 하지 못했는데, 1번의 문제를 해결하기 위해서는 자동완성 된 부분을 고쳤어야 했습니다. :(( 
``` swift
self.collectionView.register() // 이부분
```
3. DoodleCollectionViewController를 초기화 할 때 DoodleCollectionViewController의 layout을 제대로 설정해주지 않아서 🤯🤬

### 진행 상황

아직 JSON에서 가져온 DataManager가 머지되지 않아 실질적인 CollectionView의 item 개수나 data는 구현하지 않았습니다. 머지 후 구현 할 예정입니다.