### PR TITLE
Long Press - Menu Item을 통한 이미지 저장 구현

### DIFF
--- a/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
+++ b/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
@@ -357,7 +357,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = N2GAL8582Q;
+				DEVELOPMENT_TEAM = 93A6S4WHC4;
 				INFOPLIST_FILE = PhotosApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -375,7 +375,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = N2GAL8582Q;
+				DEVELOPMENT_TEAM = 93A6S4WHC4;
 				INFOPLIST_FILE = PhotosApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
+++ b/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Photos
 
 class DoodleCollectionViewController: UICollectionViewController {
     
@@ -87,7 +88,8 @@ extension DoodleCollectionViewController {
     @objc func saveImage() {
         guard let indexPath = indexPathOfSelectedCell else { return }
         let cell = collectionView.cellForItem(at: indexPath) as! DoodleImageCell
-        dataSource.saveImage(cell.doodleImage)
+        PHPhotoLibrary.shared().performChanges({
+            PHAssetChangeRequest.creationRequestForAsset(from: cell.doodleImage)
+        })
     }
 }
-                          

--- a/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
+++ b/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
@@ -10,13 +10,16 @@ import UIKit
 
 class DoodleCollectionViewController: UICollectionViewController {
     
+    private var indexPathOfSelectedCell : IndexPath?
     private let navigationBarTitle = "Doodles"
     private let delegateFlowLayout = DoodleCollectionViewDelegateFlowLayout()
     private let dataSource = DoodleCollectionViewDataSource()
+    private var longPressGestureRecognizer: UILongPressGestureRecognizer!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setupCollectionView()
+        setupGestureRecognizer()
         setupNavigationBar()
         setupNotification()
         setupUI()
@@ -25,7 +28,6 @@ class DoodleCollectionViewController: UICollectionViewController {
     private func setupCollectionView() {
         collectionView.dataSource = dataSource
         collectionView.delegate = delegateFlowLayout
-        addLongPressGesture()
         collectionView.register(DoodleImageCell.self, forCellWithReuseIdentifier: DoodleImageCell.identifier)
         collectionView.backgroundColor = .darkGray
     }
@@ -35,9 +37,9 @@ class DoodleCollectionViewController: UICollectionViewController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Close", style: .plain, target: self, action: #selector(closeButtonTapped))
     }
     
-    private func addLongPressGesture() {
-        let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(self.handleLongPressGesture(gesture:)))
-        longPressGestureRecognizer.minimumPressDuration = 0.5
+    private func setupGestureRecognizer() {
+        longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(self.handleLongPressGesture))
+        longPressGestureRecognizer.minimumPressDuration = 1
         self.collectionView.addGestureRecognizer(longPressGestureRecognizer)
     }
     
@@ -66,14 +68,15 @@ class DoodleCollectionViewController: UICollectionViewController {
         NotificationCenter.default.removeObserver(self,
                                                   name: DoodleDataManager.DoodleImagesHaveDecodedNotification,
                                                   object: nil)
+        collectionView.removeGestureRecognizer(longPressGestureRecognizer)
     }
 }
 
 extension DoodleCollectionViewController {
-    
     @objc func handleLongPressGesture(gesture: UILongPressGestureRecognizer){
         let location = gesture.location(in: self.collectionView)
         guard let indexPath = collectionView.indexPathForItem(at: location) else { return }
+        indexPathOfSelectedCell = indexPath
         guard let selectedCell = collectionView.cellForItem(at: indexPath) else { return }
         let menuItem = UIMenuItem(title: "Save", action: #selector(saveImage))
         UIMenuController.shared.menuItems = [menuItem]
@@ -82,6 +85,9 @@ extension DoodleCollectionViewController {
     }
     
     @objc func saveImage() {
-        
+        guard let indexPath = indexPathOfSelectedCell else { return }
+        let cell = collectionView.cellForItem(at: indexPath) as! DoodleImageCell
+        dataSource.saveImage(cell.doodleImage)
     }
 }
+                          

--- a/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
+++ b/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
@@ -80,7 +80,7 @@ extension DoodleCollectionViewController {
         guard let selectedCell = collectionView.cellForItem(at: indexPath) else { return }
         let menuItem = UIMenuItem(title: "Save", action: #selector(saveImage))
         UIMenuController.shared.menuItems = [menuItem]
-        UIMenuController.shared.showMenu(from: selectedCell, rect: selectedCell.frame)
+        UIMenuController.shared.showMenu(from: selectedCell, rect: selectedCell.contentView.frame)
         selectedCell.becomeFirstResponder()
     }
     

--- a/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
+++ b/PhotosApp/PhotosApp/Controllers/DoodleCollectionViewController.swift
@@ -23,14 +23,22 @@ class DoodleCollectionViewController: UICollectionViewController {
     }
     
     private func setupCollectionView() {
-        self.collectionView.dataSource = dataSource
-        self.collectionView.delegate = delegateFlowLayout
-        self.collectionView.register(DoodleImageCell.self, forCellWithReuseIdentifier: DoodleImageCell.identifier)
+        collectionView.dataSource = dataSource
+        collectionView.delegate = delegateFlowLayout
+        addLongPressGesture()
+        collectionView.register(DoodleImageCell.self, forCellWithReuseIdentifier: DoodleImageCell.identifier)
+        collectionView.backgroundColor = .darkGray
     }
-
+    
     private func setupNavigationBar() {
         navigationItem.title = navigationBarTitle
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Close", style: .plain, target: self, action: #selector(closeButtonTapped))
+    }
+    
+    private func addLongPressGesture() {
+        let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(self.handleLongPressGesture(gesture:)))
+        longPressGestureRecognizer.minimumPressDuration = 0.5
+        self.collectionView.addGestureRecognizer(longPressGestureRecognizer)
     }
     
     @objc func closeButtonTapped() {
@@ -58,5 +66,22 @@ class DoodleCollectionViewController: UICollectionViewController {
         NotificationCenter.default.removeObserver(self,
                                                   name: DoodleDataManager.DoodleImagesHaveDecodedNotification,
                                                   object: nil)
+    }
+}
+
+extension DoodleCollectionViewController {
+    
+    @objc func handleLongPressGesture(gesture: UILongPressGestureRecognizer){
+        let location = gesture.location(in: self.collectionView)
+        guard let indexPath = collectionView.indexPathForItem(at: location) else { return }
+        guard let selectedCell = collectionView.cellForItem(at: indexPath) else { return }
+        let menuItem = UIMenuItem(title: "Save", action: #selector(saveImage))
+        UIMenuController.shared.menuItems = [menuItem]
+        UIMenuController.shared.showMenu(from: selectedCell, rect: selectedCell.frame)
+        selectedCell.becomeFirstResponder()
+    }
+    
+    @objc func saveImage() {
+        
     }
 }

--- a/PhotosApp/PhotosApp/Info.plist
+++ b/PhotosApp/PhotosApp/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string></string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -60,7 +62,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string></string>
 </dict>
 </plist>

--- a/PhotosApp/PhotosApp/Models/DoodleCollectionViewDataSource.swift
+++ b/PhotosApp/PhotosApp/Models/DoodleCollectionViewDataSource.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Photos
 
 class DoodleCollectionViewDataSource: NSObject, UICollectionViewDataSource {
     

--- a/PhotosApp/PhotosApp/Models/DoodleCollectionViewDataSource.swift
+++ b/PhotosApp/PhotosApp/Models/DoodleCollectionViewDataSource.swift
@@ -26,4 +26,10 @@ class DoodleCollectionViewDataSource: NSObject, UICollectionViewDataSource {
         }
         return cell
     }
+    
+    func saveImage(_ image: UIImage) {
+        PHPhotoLibrary.shared().performChanges({
+            PHAssetChangeRequest.creationRequestForAsset(from: image)
+        })
+    }
 }

--- a/PhotosApp/PhotosApp/Models/DoodleCollectionViewDataSource.swift
+++ b/PhotosApp/PhotosApp/Models/DoodleCollectionViewDataSource.swift
@@ -26,10 +26,4 @@ class DoodleCollectionViewDataSource: NSObject, UICollectionViewDataSource {
         }
         return cell
     }
-    
-    func saveImage(_ image: UIImage) {
-        PHPhotoLibrary.shared().performChanges({
-            PHAssetChangeRequest.creationRequestForAsset(from: image)
-        })
-    }
 }

--- a/PhotosApp/PhotosApp/Views/DoodleCollectionViewDelegateFlowLayout.swift
+++ b/PhotosApp/PhotosApp/Views/DoodleCollectionViewDelegateFlowLayout.swift
@@ -16,3 +16,8 @@ class DoodleCollectionViewDelegateFlowLayout: NSObject, UICollectionViewDelegate
         return cellSize
     }
 }
+
+extension DoodleCollectionViewDelegateFlowLayout {
+    @objc func handleLongPressGesture(_ collectionView: UICollectionView, gesture: UIGestureRecognizer){
+    }
+}

--- a/PhotosApp/PhotosApp/Views/DoodleCollectionViewDelegateFlowLayout.swift
+++ b/PhotosApp/PhotosApp/Views/DoodleCollectionViewDelegateFlowLayout.swift
@@ -16,8 +16,3 @@ class DoodleCollectionViewDelegateFlowLayout: NSObject, UICollectionViewDelegate
         return cellSize
     }
 }
-
-extension DoodleCollectionViewDelegateFlowLayout {
-    @objc func handleLongPressGesture(_ collectionView: UICollectionView, gesture: UIGestureRecognizer){
-    }
-}

--- a/PhotosApp/PhotosApp/Views/DoodleImageCell.swift
+++ b/PhotosApp/PhotosApp/Views/DoodleImageCell.swift
@@ -69,3 +69,8 @@ class DoodleImageCell: UICollectionViewCell {
     }
 }
 
+extension DoodleImageCell {
+    override var canBecomeFirstResponder: Bool {
+        return true
+    }
+}


### PR DESCRIPTION
### 현재 진행 상태
iOS - GCD 작업 스케줄링 미션을 모두 구현했습니다. 🙆🏻‍♀️🦊 

### 추가 구현한 부분
Doodles 화면에서 이미지를 최소 1초동안 누르면 Save 메뉴 아이템이 뜨고, Save를 누르면 해당 이미지가 저장되도록 구현했습니다. Doodles 화면을 닫아도 저장한 이미지가 바로 보입니다.   

### 고민한 점
1. 이미지 저장을 어떤 객체가 할지 고민했습니다. 
Long Press로 눌린 위치에 있는 셀의 정보를 갖고있는 CollectionViewController가 해당 위치의 Cell에 담긴 이미지를 DataSource로 넘겨서 처리하도록 했습니다.
2. MenuItem이 꾹 누른 이미지에 위나 아래에 표시되지 않고 전혀 무관한 위치에 표시되는 문제가 있었습니다. 그래서 선택된 셀의 contentView의 프레임을 MenuItem이 보일 rect로 으로 설정해 해결했습니다.  