### PR TITLE
[hotfix] 라이브포토 badge 이미지 재사용 오류 수정

### DIFF
--- a/PhotosApp/PhotosApp/Views/PhotoCell.swift
+++ b/PhotosApp/PhotosApp/Views/PhotoCell.swift
@@ -23,4 +23,9 @@ class PhotoCell: UICollectionViewCell {
             livePhotoBadgeImageView.image = livePhotoBadgeImage
         }
     }
+    
+    override func prepareForReuse() {
+        thumbnailImage = nil
+        livePhotoBadgeImage = nil
+    }
 }


### PR DESCRIPTION
prepareForReuse()에서 nil값으로 설정해줘 해결했습니다.